### PR TITLE
Removed authentication from search service

### DIFF
--- a/src/NuGet.Indexing/IndexAnalyzer.cs
+++ b/src/NuGet.Indexing/IndexAnalyzer.cs
@@ -10,7 +10,7 @@ namespace NuGet.Indexing
 {
     public static class IndexAnalyzer
     {
-        public static string Analyze(PackageSearcherManager searcherManager)
+        public static string Analyze(PackageSearcherManager searcherManager, bool includeMemory)
         {
             if ((DateTime.UtcNow - searcherManager.WarmTimeStampUtc) > TimeSpan.FromMinutes(1))
             {
@@ -25,7 +25,10 @@ namespace NuGet.Indexing
 
                 JObject report = new JObject();
 
-                report.Add("TotalMemory", GC.GetTotalMemory(false));
+                if (includeMemory)
+                {
+                    report.Add("TotalMemory", GC.GetTotalMemory(false));
+                }
                 report.Add("NumDocs", indexReader.NumDocs());
                 report.Add("SearcherManagerIdentity", searcherManager.Id.ToString());
 

--- a/src/NuGet.Services.Search.Cloud/ServiceConfiguration.Local.cscfg
+++ b/src/NuGet.Services.Search.Cloud/ServiceConfiguration.Local.cscfg
@@ -12,7 +12,7 @@
 
             <!-- Set this to the location of a local file-system-based search index. -->
             <!-- Yes, I made this "Tmep". That's what I use for my personal temp dir to avoid conflicts. Is it stupid? Probably - anurse -->
-            <Setting name="Search.IndexPath" value="" />
+            <Setting name="Search.IndexPath" value="C:\Tmep\Lucene" />
 
             <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.Enabled" value="" />
             <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountUsername" value="" />

--- a/src/NuGet.Services.Search.Cloud/ServiceConfiguration.Local.cscfg
+++ b/src/NuGet.Services.Search.Cloud/ServiceConfiguration.Local.cscfg
@@ -11,8 +11,7 @@
             <Setting name="Http.AdminKey" value="password" />
 
             <!-- Set this to the location of a local file-system-based search index. -->
-            <!-- Yes, I made this "Tmep". That's what I use for my personal temp dir to avoid conflicts. Is it stupid? Probably - anurse -->
-            <Setting name="Search.IndexPath" value="C:\Tmep\Lucene" />
+            <Setting name="Search.IndexPath" value="" />
 
             <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.Enabled" value="" />
             <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountUsername" value="" />

--- a/src/NuGet.Services.Search/Console/Status.html
+++ b/src/NuGet.Services.Search/Console/Status.html
@@ -34,7 +34,9 @@
 
                     var html = '';
 
-                    html += '<p>Total Memory:&nbsp;<span id="totalMemory">' + bytesToSize(data.TotalMemory) + '</span></p>';
+                    if (data.TotalMemory) {
+                        html += '<p>Total Memory:&nbsp;<span id="totalMemory">' + bytesToSize(data.TotalMemory) + '</span></p>';
+                    }
                     html += '<p>Searcher Manager Identity:&nbsp;<span id="searcherManagerId">' + data.SearcherManagerIdentity + '</span></p>';
                     html += '<p>Total Documents:&nbsp;<span id="totalDocuments">' + numberFormat(data.NumDocs) + '</span></p>';
 

--- a/src/NuGet.Services.Search/DiagMiddleware.cs
+++ b/src/NuGet.Services.Search/DiagMiddleware.cs
@@ -18,7 +18,7 @@ namespace NuGet.Services.Search
         {
             Trace.TraceInformation("Diag");
 
-            await WriteResponse(context, IndexAnalyzer.Analyze(SearcherManager));
+            await WriteResponse(context, IndexAnalyzer.Analyze(SearcherManager, includeMemory: await SearchService.IsAdmin(context, challenge: false)));
         }
     }
 }

--- a/src/NuGet.Services.Search/SearchService.cs
+++ b/src/NuGet.Services.Search/SearchService.cs
@@ -80,27 +80,11 @@ namespace NuGet.Services.Search
             return tcs.Task;
         }
 
-        private static readonly IList<PathString> _adminPaths = new List<PathString>()
-        {
-            new PathString("/diag"),
-            new PathString("/fields"),
-            new PathString("/range"),
-            new PathString("/console"),
-            new PathString("/segments")
-        };
         protected override void Configure(IAppBuilder app)
         {
             // Configure the app
             app.UseErrorPage();
-            app.Use(async (context, next) =>
-            {
-                if (!_adminPaths.Any(p => context.Request.Path.StartsWithSegments(p)) ||
-                    await IsAdmin(context))
-                {
-                    await next();
-                }
-            });
-
+            
             SharedOptions sharedStaticFileOptions = new SharedOptions()
             {
                 RequestPath = new PathString("/console"),
@@ -148,14 +132,11 @@ namespace NuGet.Services.Search
                     JObject resources = new JObject();
                     response.Add("resources", resources);
 
-                    if (await IsAdmin(context, challenge: false)) 
-                    {
-                        resources.Add("range", MakeUri(context, "/range"));
-                        resources.Add("fields", MakeUri(context, "/fields"));
-                        resources.Add("console", MakeUri(context, "/console"));
-                        resources.Add("diagnostics", MakeUri(context, "/diag"));
-                        resources.Add("segments", MakeUri(context, "/segments"));
-                    }
+                    resources.Add("range", MakeUri(context, "/range"));
+                    resources.Add("fields", MakeUri(context, "/fields"));
+                    resources.Add("console", MakeUri(context, "/console"));
+                    resources.Add("diagnostics", MakeUri(context, "/diag"));
+                    resources.Add("segments", MakeUri(context, "/segments"));
                     resources.Add("query", MakeUri(context, "/query"));
 
                     await SearchMiddleware.WriteResponse(context, response.ToString());


### PR DESCRIPTION
We remove the memory fields from diagnostics if you aren't authenticated.

Incidentally this should fix NuGet/NuGetGallery#1971
