### PR TITLE
Fix NuGet/NuGetGallery#2000 by adding a log of queries

### DIFF
--- a/src/NuGet.Indexing/Searcher.cs
+++ b/src/NuGet.Indexing/Searcher.cs
@@ -9,7 +9,6 @@ using System.Text;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Diagnostics;
 
 namespace NuGet.Indexing
 {

--- a/src/NuGet.Services.Search/NuGet.Services.Search.csproj
+++ b/src/NuGet.Services.Search/NuGet.Services.Search.csproj
@@ -190,6 +190,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="QueryLog.cs" />
     <Compile Include="SegmentsMiddleware.cs" />
     <Compile Include="DiagMiddleware.cs" />
     <Compile Include="FieldsMiddleware.cs" />

--- a/src/NuGet.Services.Search/QueryLog.cs
+++ b/src/NuGet.Services.Search/QueryLog.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NuGet.Services.Storage;
+
+namespace NuGet.Services.Search
+{
+    public class QueryLog
+    {
+        private ConcurrentQueue<SearchQueryLogEntry> _records = new ConcurrentQueue<SearchQueryLogEntry>();
+
+        /// <summary>
+        /// Records a new query in the queue
+        /// </summary>
+        /// <param name="query">The query text to record</param>
+        /// <param name="projectType">The project type guids used</param>
+        /// <param name="feed">The feed queried</param>
+        /// <param name="userAgent">The User Agent that invoked the query</param>
+        /// <param name="timeTakenInMs">The duration of the query in milliseconds</param>
+        public void RecordQuery(string query, string projectType, string feed, string userAgent, int timeTakenInMs)
+        {
+            _records.Enqueue(new SearchQueryLogEntry(DateTime.UtcNow, query, projectType, feed, userAgent, timeTakenInMs));
+        }
+
+        /// <summary>
+        /// Retrieves a batch of query records from the system
+        /// </summary>
+        /// <param name="maxSize">The maximum number of records to retrieve</param>
+        /// <returns>The records retrieved. Always non-null, may be empty.</returns>
+        public IList<SearchQueryLogEntry> GetBatch(int? maxSize = null)
+        {
+            // Fetch as many as we can, or until we have maxSize items
+            IList<SearchQueryLogEntry> results = new List<SearchQueryLogEntry>();
+            SearchQueryLogEntry record;
+            while ((maxSize == null || results.Count < maxSize.Value) && _records.TryDequeue(out record))
+            {
+                results.Add(record);
+            }
+
+            return results;
+        }
+    }
+
+    public class SearchQueryLogEntry : AzureTableEntity
+    {
+        public string Query { get; private set; }
+        public string ProjectTypeGuids { get; private set; }
+        public string Feed { get; private set; }
+        public string UserAgent { get; private set; }
+        public int TimeTakenInMs { get; private set; }
+        
+        public SearchQueryLogEntry(DateTimeOffset timeStamp, string query, string projectTypeGuids, string feed, string userAgent, int timeTakenInMs)
+            : base(GetPartitionKey(timeStamp), GetRowKey(timeStamp), timeStamp)
+        {
+            Query = query;
+            ProjectTypeGuids = projectTypeGuids;
+            Feed = feed;
+            UserAgent = userAgent;
+            TimeTakenInMs = timeTakenInMs;
+        }
+
+        private static string GetRowKey(DateTimeOffset timeStamp)
+        {
+            return (DateTime.MaxValue.Ticks - timeStamp.UtcDateTime.Ticks).ToString("D19") +
+                "_" +
+                Guid.NewGuid().ToString("N");
+        }
+
+        private static string GetPartitionKey(DateTimeOffset timeStamp)
+        {
+            return (DateTime.MaxValue.Ticks - timeStamp.UtcDateTime.Date.Ticks).ToString("D19");
+        }
+    }
+}

--- a/src/NuGet.Services.Search/SearchService.cs
+++ b/src/NuGet.Services.Search/SearchService.cs
@@ -250,7 +250,17 @@ namespace NuGet.Services.Search
             batch.AddRange(entries.Select(e => TableOperation.InsertOrReplace(e)));
 
             // Upload the batch, ignore results
-            await _table.ExecuteBatchAsync(batch);
+            try
+            {
+                await _table.ExecuteBatchAsync(batch);
+            }
+            catch (Exception ex)
+            {
+                // Trace the error
+                Trace.TraceError(ex.ToString());
+
+                // Just ignore it though.
+            }
         }
     }
 }

--- a/src/NuGet.Services.Search/SearchService.cs
+++ b/src/NuGet.Services.Search/SearchService.cs
@@ -15,17 +15,23 @@ using Microsoft.Owin.StaticFiles;
 using Microsoft.Owin.StaticFiles.Infrastructure;
 using Microsoft.WindowsAzure.ServiceRuntime;
 using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Table;
 using Newtonsoft.Json.Linq;
 using NuGet.Indexing;
 using NuGet.Services.Http;
 using NuGet.Services.ServiceModel;
+using NuGet.Services.Storage;
 using Owin;
 
 namespace NuGet.Services.Search
 {
     public class SearchService : NuGetHttpService
     {
+        private static readonly int BatchSize = 1000;
+
+        private CloudTable _table;
         private PackageSearcherManager _searcherManager;
+        private QueryLog _log = new QueryLog();
 
         public override PathString BasePath
         {
@@ -42,8 +48,14 @@ namespace NuGet.Services.Search
         {
         }
 
-        protected override Task<bool> OnStart()
+        protected override async Task<bool> OnStart()
         {
+            if (Storage.Primary != null)
+            {
+                _table = Storage.Primary.Tables.Client.GetTableReference("NGSearchQueryLog");
+                await _table.CreateIfNotExistsAsync();
+            }
+
             // Load the index
             ReloadIndex();
 
@@ -63,21 +75,26 @@ namespace NuGet.Services.Search
                 // Ignore failures, they will only occur outside of Azure
             }
 
-            return base.OnStart();
+            return await base.OnStart();
         }
 
-        protected override Task OnRun()
+        protected override async Task OnRun()
         {
-            return WaitForShutdown();
-        }
-
-        // This could be moved up to the service platform
-        private static readonly object Unit = new object();
-        private Task WaitForShutdown()
-        {
-            var tcs = new TaskCompletionSource<object>();
-            Host.ShutdownToken.Register(() => tcs.SetResult(Unit)); // Don't want to return null, just a useless object
-            return tcs.Task;
+            while (!Host.ShutdownToken.IsCancellationRequested)
+            {
+                // Grab a batch of log records
+                var batch = _log.GetBatch(maxSize: BatchSize);
+                if (batch.Any())
+                {
+                    // Process the batch
+                    await UploadQueryRecords(batch);
+                }
+                else
+                {
+                    // Sleep for a few seconds to wait for more
+                    await Task.Delay(TimeSpan.FromSeconds(5));
+                }
+            }
         }
 
         protected override void Configure(IAppBuilder app)
@@ -94,9 +111,7 @@ namespace NuGet.Services.Search
             Func<PackageSearcherManager> searcherManagerThunk = () => SearcherManager;
             
             // Public endpoint(s)
-            app.Use(typeof(QueryMiddleware), "/query", searcherManagerThunk);
-               
-            // Admin endpoints
+            app.Use(typeof(QueryMiddleware), "/query", searcherManagerThunk, _log);
             app.Use(typeof(DiagMiddleware), "/diag", searcherManagerThunk);
             app.Use(typeof(FieldsMiddleware), "/fields", searcherManagerThunk);
             app.Use(typeof(RangeMiddleware), "/range", searcherManagerThunk);
@@ -226,6 +241,16 @@ namespace NuGet.Services.Search
         {
             PackageSearcherManager newIndex = CreateSearcherManager();
             Interlocked.Exchange(ref _searcherManager, newIndex);
+        }
+
+        private async Task UploadQueryRecords(IList<SearchQueryLogEntry> entries)
+        {
+            // Upload to the table!
+            var batch = new TableBatchOperation();
+            batch.AddRange(entries.Select(e => TableOperation.InsertOrReplace(e)));
+
+            // Upload the batch, ignore results
+            await _table.ExecuteBatchAsync(batch);
         }
     }
 }


### PR DESCRIPTION
Fixes NuGet/NuGetGallery#2000

The query log is stored in Azure Tables (because it allows nice Batch Append operations). At the moment, we won't be processing the data, just collecting it.
