### PR TITLE
Added NuGet-style field queries to search service

### DIFF
--- a/src/IndexMaintenance/Arguments.cs
+++ b/src/IndexMaintenance/Arguments.cs
@@ -87,18 +87,13 @@ namespace IndexMaintainance
                 dir = new AzureDirectory(acct, container.Name, new RAMDirectory());
             }
 
-            if (!args.IsLuceneQuery && !String.IsNullOrEmpty(args.Query))
-            {
-                args.Query = LuceneQueryCreator.Parse(args.Query);
-            }
-
             // Load Searcher Manager
             PackageSearcherManager manager = new PackageSearcherManager(dir, rank);
 
             // Perform the query
             string result = Searcher.Search(
                 manager, 
-                args.Query ?? String.Empty, 
+                LuceneQueryCreator.Parse(args.Query, args.IsLuceneQuery),
                 args.CountOnly, 
                 args.ProjectType ?? String.Empty, 
                 args.IncludePrerelease, 
@@ -169,7 +164,7 @@ namespace IndexMaintainance
         public void ParseQuery(ParseQueryArgs args)
         {
             Console.WriteLine("---- Converted Lucene Query ----");
-            Console.WriteLine(LuceneQueryCreator.Parse(args.Query));
+            Console.WriteLine(LuceneQueryCreator.Parse(args.Query, args.IsLuceneQuery));
             Console.WriteLine("-- End Converted Lucene Query --");
         }
 

--- a/src/IndexMaintenance/ParseQueryArgs.cs
+++ b/src/IndexMaintenance/ParseQueryArgs.cs
@@ -12,5 +12,9 @@ namespace IndexMaintainance
         [ArgPosition(0)]
         [ArgShortcut("q")]
         public string Query { get; set; }
+
+        [ArgShortcut("l")]
+        [ArgDescription("Set this flag to only do the basic parsing for raw lucene queries (basically just field name aliases)")]
+        public bool IsLuceneQuery { get; set; }
     }
 }

--- a/src/NuGet.Indexing/LuceneQueryCreator.cs
+++ b/src/NuGet.Indexing/LuceneQueryCreator.cs
@@ -1,32 +1,161 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
+using Lucene.Net.QueryParsers;
+using Lucene.Net.Search;
+using Lucene.Net.Util;
 
 namespace NuGet.Indexing
 {
     public static class LuceneQueryCreator
     {
-        public static string Parse(string nugetQuery)
+        private const string DefaultTermName = "__default";
+
+        public static Query Parse(string inputQuery, bool rawLuceneQuery)
         {
-            if (string.IsNullOrWhiteSpace(nugetQuery))
+            if (string.IsNullOrWhiteSpace(inputQuery))
             {
-                return string.Empty;
+                return new MatchAllDocsQuery();
             }
 
-            StringBuilder luceneQuery = new StringBuilder();
+            if (rawLuceneQuery)
+            {
+                return CreateRawQuery(inputQuery);
+            }
 
-            CreateFieldClause(luceneQuery, "Id", nugetQuery);
-            CreateFieldClause(luceneQuery, "Version", nugetQuery);
-            CreateFieldClause(luceneQuery, "TokenizedId", nugetQuery);
-            CreateFieldClauseAND(luceneQuery, "TokenizedId", nugetQuery, 4);
-            CreateFieldClause(luceneQuery, "ShingledId", nugetQuery);
-            CreateFieldClause(luceneQuery, "Title", nugetQuery, 2);
-            CreateFieldClauseAND(luceneQuery, "Title", nugetQuery, 4);
-            CreateFieldClause(luceneQuery, "Tags", nugetQuery);
-            CreateFieldClause(luceneQuery, "Description", nugetQuery);
-            CreateFieldClause(luceneQuery, "Authors", nugetQuery);
-            CreateFieldClause(luceneQuery, "Owners", nugetQuery);
+            // Parse the query our query parser
+            PackageQueryParser parser = new PackageQueryParser(Lucene.Net.Util.Version.LUCENE_30, DefaultTermName, new PackageAnalyzer(), rewriteIdField: true);
+            Query query = parser.Parse(inputQuery);
 
-            return luceneQuery.ToString();
+            // Process the query into portions
+            List<BooleanClause> luceneClauses = new List<BooleanClause>();
+            string nugetQuery = ExtractLuceneClauses(query, inputQuery, luceneClauses);
+
+            // Now, take the nuget query, if there is one, and process it
+            Query nugetParsedQuery = ParseNuGetQuery(nugetQuery);
+
+            // Build the lucene clauses query
+            BooleanQuery luceneQuery = BuildBooleanQuery(luceneClauses);
+
+            // Build the final query
+            return Combine(nugetParsedQuery, luceneQuery);
+        }
+
+        public static Query CreateRawQuery(string q)
+        {
+            if (String.IsNullOrEmpty(q))
+            {
+                return null;
+            }
+
+            QueryParser parser = new PackageQueryParser(Lucene.Net.Util.Version.LUCENE_30, "Title", new PackageAnalyzer());
+            Query query = parser.Parse(q);
+
+            return query;
+        }
+
+        private static string ExtractLuceneClauses(Query query, string inputQuery, List<BooleanClause> luceneClauses)
+        {
+            BooleanQuery boolQuery = query as BooleanQuery;
+            if (boolQuery != null)
+            {
+                // Process the query to extract the "nuget query" part and the "lucene filters" part
+                StringBuilder nugetQuery = new StringBuilder();
+                foreach (BooleanClause clause in boolQuery.Clauses)
+                {
+                    TermQuery tq = clause.Query as TermQuery;
+                    if (tq != null && String.Equals(tq.Term.Field, DefaultTermName, StringComparison.Ordinal))
+                    {
+                        nugetQuery.Append(tq.Term.Text);
+                        nugetQuery.Append(" ");
+                    }
+                    else
+                    {
+                        // Convert the clause to a MUST-have clause
+                        clause.Occur = Occur.MUST;
+                        luceneClauses.Add(clause);
+                    }
+                }
+                if(nugetQuery.Length > 0) {
+                    nugetQuery.Length -= 1; // Strip trailing space.
+                }
+                return nugetQuery.ToString();
+            }
+            else
+            {
+                TermQuery tq = query as TermQuery;
+                if (tq == null || !String.Equals(tq.Term.Field, DefaultTermName, StringComparison.Ordinal))
+                {
+                    luceneClauses.Add(new BooleanClause(query, Occur.SHOULD));
+                    return null;
+                }
+                else
+                {
+                    // Term Query is not null and refers to the default term
+                    Debug.Assert(tq != null);
+                    return tq.Term.Text;
+                }
+            }
+        }
+
+        private static Query ParseNuGetQuery(string nugetQuery)
+        {
+            Query nugetParsedQuery = null;
+            if (!String.IsNullOrEmpty(nugetQuery))
+            {
+                // Process the query
+                StringBuilder luceneQuery = new StringBuilder();
+
+                CreateFieldClause(luceneQuery, "Id", nugetQuery);
+                CreateFieldClause(luceneQuery, "Version", nugetQuery);
+                CreateFieldClause(luceneQuery, "TokenizedId", nugetQuery);
+                CreateFieldClauseAND(luceneQuery, "TokenizedId", nugetQuery, 4);
+                CreateFieldClause(luceneQuery, "ShingledId", nugetQuery);
+                CreateFieldClause(luceneQuery, "Title", nugetQuery, 2);
+                CreateFieldClauseAND(luceneQuery, "Title", nugetQuery, 4);
+                CreateFieldClause(luceneQuery, "Tags", nugetQuery);
+                CreateFieldClause(luceneQuery, "Description", nugetQuery);
+                CreateFieldClause(luceneQuery, "Authors", nugetQuery);
+                CreateFieldClause(luceneQuery, "Owners", nugetQuery);
+
+                PackageQueryParser parser = new PackageQueryParser(Lucene.Net.Util.Version.LUCENE_30, "Title", new PackageAnalyzer());
+                nugetParsedQuery = parser.Parse(luceneQuery.ToString());
+            }
+            return nugetParsedQuery;
+        }
+
+        private static BooleanQuery BuildBooleanQuery(List<BooleanClause> luceneClauses)
+        {
+            BooleanQuery luceneQuery = null;
+            if (luceneClauses.Count > 0)
+            {
+                luceneQuery = new BooleanQuery();
+                foreach (BooleanClause clause in luceneClauses)
+                {
+                    luceneQuery.Add(clause);
+                }
+            }
+            return luceneQuery;
+        }
+
+        private static Query Combine(Query nugetParsedQuery, BooleanQuery luceneQuery)
+        {
+            if (nugetParsedQuery == null)
+            {
+                return luceneQuery;
+            }
+            else if (luceneQuery == null)
+            {
+                return nugetParsedQuery;
+            }
+            else
+            {
+                BooleanQuery q = new BooleanQuery();
+                q.Clauses.Add(new BooleanClause(nugetParsedQuery, Occur.SHOULD));
+                q.Clauses.Add(new BooleanClause(luceneQuery, Occur.SHOULD));
+                return q;
+            }
         }
 
         static void CreateFieldClause(StringBuilder luceneQuery, string field, string query, float boost = 1.0f)

--- a/src/NuGet.Indexing/LuceneQueryCreator.cs
+++ b/src/NuGet.Indexing/LuceneQueryCreator.cs
@@ -153,7 +153,7 @@ namespace NuGet.Indexing
             {
                 BooleanQuery q = new BooleanQuery();
                 q.Clauses.Add(new BooleanClause(nugetParsedQuery, Occur.SHOULD));
-                q.Clauses.Add(new BooleanClause(luceneQuery, Occur.SHOULD));
+                q.Clauses.AddRange(luceneQuery.Clauses);
                 return q;
             }
         }

--- a/src/NuGet.Indexing/PackageQueryParser.cs
+++ b/src/NuGet.Indexing/PackageQueryParser.cs
@@ -11,7 +11,7 @@ namespace NuGet.Indexing
         static IDictionary<string, string> Alternatives = new Dictionary<string, string>
         {
             { "id", "Id" },
-            { "exactid", "Id" }, // ExactId will map to Id, but will bypass the rewriter in BuildQuery
+            { "packageid", "Id" }, // PackageId will map to Id, but will bypass the rewriter in BuildQuery and be an exact match
             { "version", "Version" },
             { "tokenizedid", "TokenizedId" },
             { "shingledid", "ShingledId" },

--- a/src/NuGet.Indexing/PackageQueryParser.cs
+++ b/src/NuGet.Indexing/PackageQueryParser.cs
@@ -2,6 +2,7 @@
 using Lucene.Net.QueryParsers;
 using Lucene.Net.Search;
 using System.Collections.Generic;
+using System;
 
 namespace NuGet.Indexing
 {
@@ -10,8 +11,10 @@ namespace NuGet.Indexing
         static IDictionary<string, string> Alternatives = new Dictionary<string, string>
         {
             { "id", "Id" },
+            { "exactid", "Id" }, // ExactId will map to Id, but will bypass the rewriter in BuildQuery
             { "version", "Version" },
             { "tokenizedid", "TokenizedId" },
+            { "shingledid", "ShingledId" },
             { "title", "Title" },
             { "description", "Description" },
             { "tag", "Tags" },
@@ -21,30 +24,37 @@ namespace NuGet.Indexing
             { "owner", "Owners" },
             { "owners", "Owners" },
         };
+        private bool _rewriteIdField;
 
         public PackageQueryParser(Lucene.Net.Util.Version matchVersion, string f, Analyzer a) :
+            this(matchVersion, f, a, rewriteIdField: false)
+        {
+        }
+
+        public PackageQueryParser(Lucene.Net.Util.Version matchVersion, string f, Analyzer a, bool rewriteIdField) :
             base(matchVersion, f, a)
         {
+            _rewriteIdField = rewriteIdField;
         }
 
         protected override Query GetPrefixQuery(string field, string termStr)
         {
-            return base.GetPrefixQuery(Substitute(field), termStr);
+            return BuildQuery(field, termStr, base.GetPrefixQuery);
         }
 
         protected override Query GetWildcardQuery(string field, string termStr)
         {
-            return base.GetWildcardQuery(Substitute(field), termStr);
+            return BuildQuery(field, termStr, base.GetWildcardQuery);
         }
 
         protected override Query GetFieldQuery(string field, string queryText, int slop)
         {
-            return base.GetFieldQuery(Substitute(field), queryText, slop);
+            return BuildQuery(field, queryText, (f, q) => base.GetFieldQuery(f, q, slop));
         }
 
         protected override Query GetFieldQuery(string field, string queryText)
         {
-            return base.GetFieldQuery(Substitute(field), queryText);
+            return BuildQuery(field, queryText, base.GetFieldQuery);
         }
 
         private string Substitute(string fieldName)
@@ -57,6 +67,24 @@ namespace NuGet.Indexing
                 return subStitutedFieldName;
             }
             return fieldName;
+        }
+
+        private Query BuildQuery(string field, string termStr, Func<string, string, Query> baseQueryBuilder)
+        {
+            if (_rewriteIdField && String.Equals(field, "id", StringComparison.OrdinalIgnoreCase))
+            {
+                // Actually, build an equivalent query against TokenizedId, ShingledId and Id
+                BooleanQuery boolQuery = new BooleanQuery();
+                boolQuery.Add(new BooleanClause(baseQueryBuilder("Id", termStr), Occur.SHOULD));
+                boolQuery.Add(new BooleanClause(baseQueryBuilder("TokenizedId", termStr), Occur.SHOULD));
+                boolQuery.Add(new BooleanClause(baseQueryBuilder("ShingledId", termStr), Occur.SHOULD));
+                return boolQuery;
+            }
+            else
+            {
+                // Just rewrite the field name
+                return baseQueryBuilder(Substitute(field), termStr);
+            }
         }
     }
 }

--- a/src/NuGet.Indexing/RankingsScoreQuery.cs
+++ b/src/NuGet.Indexing/RankingsScoreQuery.cs
@@ -9,16 +9,23 @@ namespace NuGet.Indexing
     public class RankingScoreQuery : CustomScoreQuery
     {
         IDictionary<string, int> _rankings;
+        public Query Query { get; private set; }
 
         public RankingScoreQuery(Query q, IDictionary<string, int> rankings)
             : base(q)
         {
+            Query = q;
             _rankings = rankings;
         }
 
         protected override CustomScoreProvider GetCustomScoreProvider(IndexReader reader)
         {
             return new RankingScoreProvider(reader, _rankings);
+        }
+
+        public override string ToString()
+        {
+            return "rank(" + Query.ToString() + ")";
         }
 
         private class RankingScoreProvider : CustomScoreProvider

--- a/src/NuGet.Services.Search/Console/Index.html
+++ b/src/NuGet.Services.Search/Console/Index.html
@@ -12,8 +12,10 @@
         <div style="margin:6px">
             <span style="font-size:large;font-weight:bold;color:black">Test</span>
             <div id="query-div" style="display:inline-block;text-align:center;width:720px">
-                <input id="query" size="25" type="text">
-                <button id="go">Go</button>
+                <form id="search" action="#">
+                    <input id="query" size="25" type="text">
+                    <button id="go" type="submit">Go</button>
+                </form>
                 &nbsp;&nbsp;&nbsp;
                 &nbsp;&nbsp;&nbsp;
                 <select id="prerelease">
@@ -32,9 +34,7 @@
         </div>
     </div>
 
-    <button id="show-diagnostics">Diagnostics</button>
-
-    <div id="diagnostics" style="border-width:3px;border-style:solid;border-color:green;display:none;margin:4px">
+    <div id="diagnostics" style="border-width:3px;border-style:solid;border-color:green;margin:4px">
         <div style="margin:4px">
 
             <span style="font-size:large;font-weight:bold;color:green">Diagnostics</span>
@@ -64,7 +64,6 @@
             </div>
 
             <div style="width:100px;display:inline-block;">
-                <input id="explanation" type="checkbox">Explanation
                 <input id="ignore-filter" type="checkbox">No Filter&nbsp;&nbsp;
                 <input id="send-query" type="checkbox" checked>Send Raw
             </div>
@@ -108,23 +107,24 @@
             alert("An error occurred!");
         });
 
-        var displayPackage = function (data, i, skip) {
+        var displayPackage = function (data, i, query) {
 
-            var number = (skip * 20) + (i + 1);
+            var number = (query.skip * 20) + (i + 1);
 
-            var html = '';
+            var html = '<div class="package-entry">';
 
             var title = data[i].Title;
             if (title === null || title === '') {
                 title = data[i].PackageRegistration.Id;
             }
-
             html += '<p>';
             html += '<span class="result-number">' + number + '</span>&nbsp;<span class="result-title">' + title + '</span>';
-            html += '&nbsp;&nbsp;<button id="result-index-' + i + '" class="result-json">JSON</button>'
+            html += '<button class="result-button result-json">JSON</button>';
+            html += '<button class="result-button result-explain">Explain</button>';
             html += '</p>';
 
-            html += '<div class="json-display"><div class="json-display-content" id="result-display-json-' + i + '"></div></div>';
+            html += '<div class="json-display">' + displayJson(data[i]) + '</div>';
+            html += '<div class="explanation">' + displayExplanation(data, i) + '</div>';
 
             html += '<div class="result-details-div">';
 
@@ -140,6 +140,7 @@
                 html += '<p><span class="result-tags">' + data[i].Tags + '</span></p>';
             }
 
+            html += '</div>';
             html += '</div>';
 
             return html;
@@ -162,7 +163,6 @@
 
             var html = '';
 
-            html += '<div class="explanation">'
             html += '<div style="margin-left:20px">';
             html += '<p>';
             html += ' <span style="color:black">Rank:</span>';
@@ -193,7 +193,6 @@
             html += '<p><span class="term-name">ProjectGuidRankings:</span> <div class="term-value">' + displayArray(data[i].diagnostics.ProjectGuidRankings) + '</div></p>';
 
             html += '<pre style="color:blue">' + data[i].diagnostics.Explanation + '</pre>';
-            html += '</div>';
             html += '</div>';
 
             return html;
@@ -236,8 +235,8 @@
                     ignoreFilter: query.ignoreFilter,
                     luceneQuery: query.luceneQuery
                 };
-                $.get('search', navQuery, function (data, status) {
-                    updateResultsDiv(navQuery, total, data.data);
+                $.get('/search/query', navQuery, function (data, status) {
+                    updateResultsDiv(navQuery, total, data.data, data.query);
                 });
             };
         }
@@ -250,7 +249,7 @@
             if (skip > 0) {
                 html += '<button id="prev">Prev</button>'
             }
-            if ((total - ((skip + 1) * 20)) > 0) {
+            if ((total - (skip + 20)) > 0) {
                 html += '<button id="next">Next</button>'
             }
             html += '</div>';
@@ -258,46 +257,32 @@
             return html;
         }
 
-        var showJson = function (data) {
-            return function () {
-                var id = $(this).attr('Id');
-                var i = parseInt(id.substr(13));
-                if ($('#result-display-json-' + i).text() === '') {
-                    var resultObj = JSON.parse(JSON.stringify(data[i]));
-                    delete resultObj['diagnostics'];
-                    var div = $('#result-display-json-' + i);
-                    div.html(json2html(resultObj));
-                    div.parent().css('display', 'block');
-                }
-                else {
-                    var div = $('#result-display-json-' + i);
-                    div.html('')
-                    div.parent().css('display', 'none');
-                }
-            };
+        var displayJson = function (data) {
+            var resultObj = JSON.parse(JSON.stringify(data));
+            delete resultObj['diagnostics'];
+            return json2html(resultObj);
         }
 
-        var updateResultsDiv = function (query, total, data) {
+        var updateResultsDiv = function (query, total, data, executedQuery) {
 
             var html = '';
 
             html += '<p>Total: ' + total + '</p>';
 
+            if (executedQuery) {
+                html += '<p class="executedQuery">Query: <span>' + executedQuery + '</span></p>';
+            }
+
             for (var i = 0; i < data.length; i += 1) {
-                html += displayPackage(data, i, query.skip);
-                if (query.explanation) {
-                    html += displayExplanation(data, i);
-                }
+                html += displayPackage(data, i, query);
             }
 
             html += displayNavigationButtons(total, query.skip);
 
             $('#results-div').html(html);
 
-            $('#prev').click(createNavigationFunction(query, total, query.skip - 1));
-            $('#next').click(createNavigationFunction(query, total, query.skip + 1));
-
-            $('.result-json').click(showJson(data));
+            $('#prev').click(createNavigationFunction(query, total, query.skip - 10));
+            $('#next').click(createNavigationFunction(query, total, query.skip + 10));
         }
 
         var addBoost = function(term, boost)
@@ -405,7 +390,6 @@
             var prerelease = $('#prerelease').val();
             var sortBy = $('#sortBy').val();
             var feed = $('#feed').val();
-            var explanation = $('#explanation').is(':checked');
             var ignoreFilter = $('#ignore-filter').is(':checked');
 
             var query = {
@@ -416,7 +400,7 @@
                 sortBy: sortBy,
                 skip: 0,
                 take: 20,
-                explanation: explanation,
+                explanation: true,
                 ignoreFilter: ignoreFilter
             };
 
@@ -436,11 +420,11 @@
 
                     if (status === 'success') {
 
-                        $.get('search', query, function (data, status) {
+                        $.get('/search/query', query, function (data, status) {
 
                             if (status === 'success') {
 
-                                updateResultsDiv(query, totalHits, data.data);
+                                updateResultsDiv(query, totalHits, data.data, data.executedQuery);
                             }
                         });
                     }
@@ -452,7 +436,7 @@
 
                     if (status === 'success') {
 
-                        updateResultsDiv(query, data.totalHits, data.data);
+                        updateResultsDiv(query, data.totalHits, data.data, data.executedQuery);
                     }
                 });
             }
@@ -495,19 +479,6 @@
             console.log(expectedPackageId + ' ' + contactDetails);
         }
 
-        var diagnosticsVisible = false;
-
-        var toggleDiagnostics = function () {
-            if (diagnosticsVisible === false) {
-                $('#diagnostics').css('display', 'block');
-                diagnosticsVisible = true;
-            }
-            else {
-                $('#diagnostics').css('display', 'none');
-                diagnosticsVisible = false;
-            }
-        }
-
         $(document).ready(function () {
 
             $('#query').keyup(function () {
@@ -521,13 +492,18 @@
                 }
             });
 
-            $('#go').click(go);
+            $('#search').submit(go);
 
             $('#expectedPackageId').val(defaultExpectedPackageId);
             $('#contactDetails').val(defaultContactDetails);
             $('#submitFeedback').click(submitFeedback);
 
-            $('#show-diagnostics').click(toggleDiagnostics)
+            $('#results-div').on('click', '.result-explain', function () {
+                $(this).parent().siblings('.explanation').slideToggle();
+            });
+            $('#results-div').on('click', '.result-json', function () {
+                $(this).parent().siblings('.json-display').slideToggle();
+            });
         });
     </script>
 </body>

--- a/src/NuGet.Services.Search/Console/Master.css
+++ b/src/NuGet.Services.Search/Console/Master.css
@@ -84,12 +84,10 @@ textarea {
     color:blue;
 }
 
-.result-json {
+.result-button {
     font-size: xx-small;
     font-weight:bold;
     color:blue;
-    height:16px;
-    width:40px;
     margin:10px;
 }
 
@@ -164,6 +162,18 @@ textarea {
     margin:10px;
 }
 
+.explanation {
+    display: none;
+}
+
+p.executedQuery {
+}
+
+p.executedQuery span {
+    font-family: Consolas, 'Lucida Console', 'Courier New', monospace;
+    font-size: 12pt;
+}
+
 /* styles for D3 graph of segments */
 
 .axis path,
@@ -187,4 +197,8 @@ textarea {
 #totalDocuments {
   font-size: 2em;
   font-family: 'Courier New';
+}
+
+form#search {
+    display: inline-block;
 }

--- a/src/NuGet.Services.Search/QueryMiddleware.cs
+++ b/src/NuGet.Services.Search/QueryMiddleware.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Lucene.Net.Index;
+using Lucene.Net.Search;
 using Microsoft.Owin;
 using NuGet.Indexing;
 
@@ -71,12 +72,18 @@ namespace NuGet.Services.Search
             string args = string.Format("Searcher.Search(..., {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10})", q, countOnly, projectType, includePrerelease, feed, sortBy, skip, take, includeExplanation, ignoreFilter, luceneQuery);
             Trace.TraceInformation(args);
 
-            if (!luceneQuery)
-            {
-                q = LuceneQueryCreator.Parse(q);
-            }
-
-            string content = Searcher.Search(SearcherManager, q, countOnly, projectType, includePrerelease, feed, sortBy, skip, take, includeExplanation, ignoreFilter);
+            string content = NuGet.Indexing.Searcher.Search(
+                SearcherManager, 
+                LuceneQueryCreator.Parse(q, luceneQuery), 
+                countOnly, 
+                projectType, 
+                includePrerelease, 
+                feed, 
+                sortBy, 
+                skip, 
+                take, 
+                includeExplanation, 
+                ignoreFilter);
 
             await WriteResponse(context, content);
         }


### PR DESCRIPTION
Fixes the in-flight 3.0.3 release to support existing field queries. Now, we apply all field filters ("id:", "title:", etc.) as **must-have** clauses, meaning only documents that match those fields will be accepted. We do alias "id:" to the "TokenizedId" and "ShingledId" fields because users expect that to be a substring match.

Also:
- Queries from the test site always generate explanations, but they are collapsed by default
- Explanation queries also include the final, raw Lucene query executed for debugging
