### PR TITLE
Deduplicate range query results.

### DIFF
--- a/src/NuGet.Indexing/KeyCollector.cs
+++ b/src/NuGet.Indexing/KeyCollector.cs
@@ -8,11 +8,11 @@ namespace NuGet.Indexing
     {
         private int[] _keys;
         private int[] _checksums;
-        private JObject _result;
+        private IList<KeyValuePair<int, int>> _pairs;
 
-        public KeyCollector(JObject result)
+        public KeyCollector(IList<KeyValuePair<int, int>> pairs)
         {
-            _result = result;
+            _pairs = pairs;
         }
 
         public override bool AcceptsDocsOutOfOrder
@@ -22,7 +22,7 @@ namespace NuGet.Indexing
 
         public override void Collect(int docID)
         {
-            _result.Add(_keys[docID].ToString(), _checksums[docID]);
+            _pairs.Add(new KeyValuePair<int, int>(_keys[docID], _checksums[docID]));
         }
 
         public override void SetNextReader(Lucene.Net.Index.IndexReader reader, int docBase)

--- a/src/NuGet.Indexing/KeyCollector.cs
+++ b/src/NuGet.Indexing/KeyCollector.cs
@@ -8,9 +8,9 @@ namespace NuGet.Indexing
     {
         private int[] _keys;
         private int[] _checksums;
-        private IList<KeyValuePair<int, int>> _pairs;
+        private IList<DocumentKey> _pairs;
 
-        public KeyCollector(IList<KeyValuePair<int, int>> pairs)
+        public KeyCollector(IList<DocumentKey> pairs)
         {
             _pairs = pairs;
         }
@@ -22,7 +22,7 @@ namespace NuGet.Indexing
 
         public override void Collect(int docID)
         {
-            _pairs.Add(new KeyValuePair<int, int>(_keys[docID], _checksums[docID]));
+            _pairs.Add(new DocumentKey(_keys[docID], docID, _checksums[docID]));
         }
 
         public override void SetNextReader(Lucene.Net.Index.IndexReader reader, int docBase)
@@ -33,6 +33,20 @@ namespace NuGet.Indexing
 
         public override void SetScorer(Scorer scorer)
         {
+        }
+    }
+
+    public class DocumentKey
+    {
+        public int PackageKey { get; private set; }
+        public int DocumentId { get; private set; }
+        public int Checksum { get; private set; }
+
+        public DocumentKey(int packageKey, int documentId, int checksum)
+        {
+            PackageKey = packageKey;
+            DocumentId = documentId;
+            Checksum = checksum;
         }
     }
 }

--- a/src/NuGet.Indexing/Searcher.cs
+++ b/src/NuGet.Indexing/Searcher.cs
@@ -30,9 +30,17 @@ namespace NuGet.Indexing
             {
                 NumericRangeQuery<int> numericRangeQuery = NumericRangeQuery.NewIntRange("Key", minKey, maxKey, true, true);
 
-                JObject keys = new JObject();
-                searcher.Search(numericRangeQuery, new KeyCollector(keys));
+                List<KeyValuePair<int, int>> pairs = new List<KeyValuePair<int, int>>();
+                searcher.Search(numericRangeQuery, new KeyCollector(pairs));
 
+                // Group by key
+                IEnumerable<IGrouping<int, KeyValuePair<int, int>>> groups = pairs.GroupBy(p => p.Key);
+
+                // De-duplicate
+                IEnumerable<KeyValuePair<int, int>> deduped = groups.Select(g => g.First());
+                
+                JObject keys = new JObject();
+                keys.Add(deduped.Select(p => new JProperty(p.Key.ToString(), p.Value)));
                 return keys.ToString();
             }
             finally

--- a/src/NuGet.Indexing/Searcher.cs
+++ b/src/NuGet.Indexing/Searcher.cs
@@ -30,17 +30,17 @@ namespace NuGet.Indexing
             {
                 NumericRangeQuery<int> numericRangeQuery = NumericRangeQuery.NewIntRange("Key", minKey, maxKey, true, true);
 
-                List<KeyValuePair<int, int>> pairs = new List<KeyValuePair<int, int>>();
+                List<DocumentKey> pairs = new List<DocumentKey>();
                 searcher.Search(numericRangeQuery, new KeyCollector(pairs));
 
                 // Group by key
-                IEnumerable<IGrouping<int, KeyValuePair<int, int>>> groups = pairs.GroupBy(p => p.Key);
+                IEnumerable<IGrouping<int, DocumentKey>> groups = pairs.GroupBy(p => p.PackageKey);
 
                 // De-duplicate
-                IEnumerable<KeyValuePair<int, int>> deduped = groups.Select(g => g.First());
+                IEnumerable<DocumentKey> deduped = groups.Select(g => g.First());
                 
                 JObject keys = new JObject();
-                keys.Add(deduped.Select(p => new JProperty(p.Key.ToString(), p.Value)));
+                keys.Add(deduped.Select(p => new JProperty(p.PackageKey.ToString(), p.Checksum)));
                 return keys.ToString();
             }
             finally


### PR DESCRIPTION
This change is in NuGet.Indexing. After accepting it, a build will be created. Then I will update the version of NuGet.Indexing used by the work service.

After that, I can deploy the new work service and all should be well again :).
