### PR TITLE
Johtaylo fix language search

### DIFF
--- a/src/NuGet.Indexing/IndexTask.cs
+++ b/src/NuGet.Indexing/IndexTask.cs
@@ -22,6 +22,11 @@ namespace NuGet.Indexing
         public string SqlConnectionString { get; set; }
         public bool WhatIf { get; set; }
 
+        public IndexTask()
+        {
+            Log = Console.Out;
+        }
+
         protected Lucene.Net.Store.Directory GetDirectory()
         {
             Lucene.Net.Store.Directory directory = null;

--- a/src/NuGet.Indexing/PackageIndexing.cs
+++ b/src/NuGet.Indexing/PackageIndexing.cs
@@ -216,14 +216,10 @@ namespace NuGet.Indexing
         {
             if (!string.IsNullOrWhiteSpace(language))
             {
-                int suffixIndex = id.LastIndexOf('.') + 1;
-                if (suffixIndex < id.Length)
+                string languageSuffix = "." + language.Trim();
+                if (id.EndsWith(languageSuffix, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    string suffix = id.Substring(suffixIndex);
-                    if (suffix.Trim().Equals(language.Trim(), StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        return 0.1f;
-                    }
+                    return 0.1f;
                 }
             }
             return 1.0f;

--- a/src/NuGet.Indexing/PackageIndexing.cs
+++ b/src/NuGet.Indexing/PackageIndexing.cs
@@ -212,13 +212,21 @@ namespace NuGet.Indexing
             Add(doc, name, value.ToString(CultureInfo.InvariantCulture), store, index, termVector, boost);
         }
 
-        private static float DetermineLanguageBoost(string language)
+        private static float DetermineLanguageBoost(string id, string language)
         {
-            if (string.IsNullOrWhiteSpace(language) || language.TrimStart().StartsWith("en", StringComparison.InvariantCultureIgnoreCase))
+            if (!string.IsNullOrWhiteSpace(language))
             {
-                return 1.0f;
+                int suffixIndex = id.LastIndexOf('.') + 1;
+                if (suffixIndex < id.Length)
+                {
+                    string suffix = id.Substring(suffixIndex);
+                    if (suffix.Trim().Equals(language.Trim(), StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        return 0.1f;
+                    }
+                }
             }
-            return 0.1f;
+            return 1.0f;
         }
 
         // ----------------------------------------------------------------------------------------------------------------------------------------
@@ -300,7 +308,7 @@ namespace NuGet.Indexing
 
             Add(doc, "Data", data, Field.Store.YES, Field.Index.NO, Field.TermVector.NO);
 
-            doc.Boost = DetermineLanguageBoost(package.Language);
+            doc.Boost = DetermineLanguageBoost(package.PackageRegistration.Id, package.Language);
 
             return doc;
         }

--- a/src/NuGet.Indexing/PackageIndexing.cs
+++ b/src/NuGet.Indexing/PackageIndexing.cs
@@ -212,6 +212,15 @@ namespace NuGet.Indexing
             Add(doc, name, value.ToString(CultureInfo.InvariantCulture), store, index, termVector, boost);
         }
 
+        private static float DetermineLanguageBoost(string language)
+        {
+            if (string.IsNullOrWhiteSpace(language) || language.TrimStart().StartsWith("en", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return 1.0f;
+            }
+            return 0.1f;
+        }
+
         // ----------------------------------------------------------------------------------------------------------------------------------------
 
         private static Document CreateLuceneDocument(IndexDocumentData documentData)
@@ -290,6 +299,8 @@ namespace NuGet.Indexing
             string data = obj.ToString();
 
             Add(doc, "Data", data, Field.Store.YES, Field.Index.NO, Field.TermVector.NO);
+
+            doc.Boost = DetermineLanguageBoost(package.Language);
 
             return doc;
         }

--- a/src/NuGet.Indexing/Searcher.cs
+++ b/src/NuGet.Indexing/Searcher.cs
@@ -9,7 +9,6 @@ using System.Text;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Diagnostics;
 using Newtonsoft.Json;
 
 namespace NuGet.Indexing

--- a/src/NuGet.Services.Search.MiniTester/NuGet.Services.Search.MiniTester.csproj
+++ b/src/NuGet.Services.Search.MiniTester/NuGet.Services.Search.MiniTester.csproj
@@ -44,9 +44,6 @@
     <Reference Include="Autofac.Integration.WebApi">
       <HintPath>..\..\packages\Autofac.WebApi5.3.0.0-rc1\lib\net45\Autofac.Integration.WebApi.dll</HintPath>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
-    </Reference>
     <Reference Include="Lucene.Net">
       <HintPath>..\..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
     </Reference>

--- a/src/NuGet.Services.Search.MiniTester/Startup.cs
+++ b/src/NuGet.Services.Search.MiniTester/Startup.cs
@@ -24,7 +24,7 @@ namespace NuGet.Services.Search.MiniTester
                     "search"),
                 CreateSearcherManager);
             search.ReloadIndex();
-            search.Configure(app);
+            app.Map(new PathString("/search"), a => search.Configure(a));
         }
 
         private PackageSearcherManager CreateSearcherManager()

--- a/src/NuGet.Services.Search.MiniTester/Web.config
+++ b/src/NuGet.Services.Search.MiniTester/Web.config
@@ -6,7 +6,7 @@
 <configuration>
     <appSettings>
         <!-- Specify the path to the Lucene Index here-->
-        <add key="IndexLocation" value="C:\data\index20140519" />
+        <add key="IndexLocation" value="C:\data\index20140520" />
     </appSettings>
     <system.web>
         <compilation debug="true" targetFramework="4.5" />

--- a/src/NuGet.Services.Search.MiniTester/Web.config
+++ b/src/NuGet.Services.Search.MiniTester/Web.config
@@ -6,7 +6,7 @@
 <configuration>
     <appSettings>
         <!-- Specify the path to the Lucene Index here-->
-        <add key="IndexLocation" value="C:\Tmep\Lucene" />
+        <add key="IndexLocation" value="C:\data\index20140519" />
     </appSettings>
     <system.web>
         <compilation debug="true" targetFramework="4.5" />


### PR DESCRIPTION
Added code to boost non-english and non-default down in the indexing.

This means that you shouldn't see lot of the same package with different languages in the results. But the non-english package should still be findable.

Fixes NuGet/NuGetGallery#2156
