### PR TITLE
Added the ability to place stats in a separate container

### DIFF
--- a/src/NuGet.Indexing/DownloadCounts.cs
+++ b/src/NuGet.Indexing/DownloadCounts.cs
@@ -9,6 +9,8 @@ namespace NuGet.Indexing
 {
     public abstract class DownloadCounts
     {
+        protected static readonly string ReportName = "downloads.v1.json";
+
         public abstract string Path { get; }
         protected abstract JObject LoadJson();
 

--- a/src/NuGet.Indexing/IndexTask.cs
+++ b/src/NuGet.Indexing/IndexTask.cs
@@ -50,8 +50,8 @@ namespace NuGet.Indexing
             {
                 manager = new PackageSearcherManager(
                     GetDirectory(),
-                    new StorageRankings(StorageAccount),
-                    new StorageDownloadCounts(StorageAccount));
+                    new StorageRankings(StorageAccount, "ng-search", "data"),
+                    new StorageDownloadCounts(StorageAccount, "ng-search", "data"));
             }
             else if (!string.IsNullOrEmpty(Folder))
             {

--- a/src/NuGet.Indexing/Rankings.cs
+++ b/src/NuGet.Indexing/Rankings.cs
@@ -11,6 +11,8 @@ namespace NuGet.Indexing
 {
     public abstract class Rankings
     {
+        protected static readonly string ReportName = "rankings.v1.json";
+
         public abstract string Path { get; }
         protected abstract JObject LoadJson();
 

--- a/src/NuGet.Indexing/Searcher.cs
+++ b/src/NuGet.Indexing/Searcher.cs
@@ -9,7 +9,6 @@ using System.Text;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Diagnostics;
 using Newtonsoft.Json;
 
 namespace NuGet.Indexing

--- a/src/NuGet.Indexing/StorageDownloadCounts.cs
+++ b/src/NuGet.Indexing/StorageDownloadCounts.cs
@@ -13,24 +13,13 @@ namespace NuGet.Indexing
     {
         CloudBlockBlob _blob;
 
-        public override string Path { get { return _blob.Uri.AbsoluteUri; } }
+        public override string Path
+        { get { return _blob.Uri.AbsoluteUri; } }
 
-        public StorageDownloadCounts(string connectionString) : this(CloudStorageAccount.Parse(connectionString))
-        {
-        }
-
-        public StorageDownloadCounts(CloudStorageAccount storageAccount) : this(storageAccount, "ng-search")
-        {
-        }
-
-        public StorageDownloadCounts(CloudStorageAccount storageAccount, string containerName)
-            : this(storageAccount.CreateCloudBlobClient().GetContainerReference(containerName))
-        {
-        }
-
-        public StorageDownloadCounts(CloudBlobContainer container) : this(container.GetBlockBlobReference(@"data/downloads.v1.json"))
-        {
-        }
+        public StorageDownloadCounts(CloudStorageAccount account, string container)
+            : this(GetBlob(account, container, folder: null)) { }
+        public StorageDownloadCounts(CloudStorageAccount account, string container, string folder)
+            : this(GetBlob(account, container, folder)) { }
 
         public StorageDownloadCounts(CloudBlockBlob blob)
         {
@@ -46,6 +35,15 @@ namespace NuGet.Indexing
             string json = _blob.DownloadText();
             JObject obj = JObject.Parse(json);
             return obj;
+        }
+
+        private static CloudBlockBlob GetBlob(CloudStorageAccount account, string containerName, string folder)
+        {
+            var container = account.CreateCloudBlobClient().GetContainerReference(containerName);
+            return container.GetBlockBlobReference(
+                String.IsNullOrEmpty(folder) ?
+                    ReportName :
+                    (folder + "/" + ReportName));
         }
     }
 }

--- a/src/NuGet.Indexing/StorageRankings.cs
+++ b/src/NuGet.Indexing/StorageRankings.cs
@@ -15,22 +15,10 @@ namespace NuGet.Indexing
         
         public override string Path { get { return _blob.Uri.AbsoluteUri; } }
 
-        public StorageRankings(string connectionString) : this(CloudStorageAccount.Parse(connectionString))
-        {
-        }
-
-        public StorageRankings(CloudStorageAccount storageAccount) : this(storageAccount, "ng-search")
-        {
-        }
-
-        public StorageRankings(CloudStorageAccount storageAccount, string containerName)
-            : this(storageAccount.CreateCloudBlobClient().GetContainerReference(containerName))
-        {
-        }
-
-        public StorageRankings(CloudBlobContainer container) : this(container.GetBlockBlobReference(@"data/rankings.v1.json"))
-        {
-        }
+        public StorageRankings(CloudStorageAccount account, string container)
+            : this(GetBlob(account, container, folder: null)) { }
+        public StorageRankings(CloudStorageAccount account, string container, string folder)
+            : this(GetBlob(account, container, folder)) { }
 
         public StorageRankings(CloudBlockBlob blob)
         {
@@ -46,6 +34,15 @@ namespace NuGet.Indexing
             string json = _blob.DownloadText();
             JObject obj = JObject.Parse(json);
             return obj;
+        }
+
+        private static CloudBlockBlob GetBlob(CloudStorageAccount account, string containerName, string folder)
+        {
+            var container = account.CreateCloudBlobClient().GetContainerReference(containerName);
+            return container.GetBlockBlobReference(
+                String.IsNullOrEmpty(folder) ?
+                    ReportName :
+                    (folder + "/" + ReportName));
         }
     }
 }

--- a/src/NuGet.Services.Search.Cloud/ServiceConfiguration.Cloud.cscfg
+++ b/src/NuGet.Services.Search.Cloud/ServiceConfiguration.Cloud.cscfg
@@ -16,6 +16,8 @@
             <!-- Set this to a non-empty value to CHANGE the container name used for storing the index -->
             <!-- The default value, if this is empty, is 'ng-search' -->
             <Setting name="Search.IndexContainer" value="" />
+            <!-- Set this to a non-empty value to use a separate container to hold the stats -->
+            <Setting name="Search.StatsContainer" value="" />
 
             <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.Enabled" value="" />
             <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountUsername" value="" />

--- a/src/NuGet.Services.Search.Cloud/ServiceConfiguration.Local.cscfg
+++ b/src/NuGet.Services.Search.Cloud/ServiceConfiguration.Local.cscfg
@@ -16,6 +16,8 @@
             <!-- Set this to a non-empty value to CHANGE the container name used for storing the index -->
             <!-- The default value, if this is empty, is 'ng-search' -->
             <Setting name="Search.IndexContainer" value="" />
+            <!-- Set this to a non-empty value to use a separate container to hold the stats -->
+            <Setting name="Search.StatsContainer" value="" />
 
             <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.Enabled" value="" />
             <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountUsername" value="" />

--- a/src/NuGet.Services.Search.Cloud/ServiceDefinition.csdef
+++ b/src/NuGet.Services.Search.Cloud/ServiceDefinition.csdef
@@ -23,6 +23,7 @@
 
             <Setting name="Search.IndexPath" />
             <Setting name="Search.IndexContainer" />
+            <Setting name="Search.StatsContainer" />
         </ConfigurationSettings>
         <Certificates>
             <Certificate name="SSL" permissionLevel="limitedOrElevated" storeLocation="LocalMachine" storeName="My" />

--- a/src/NuGet.Services.Search.MiniTester/NuGet.Services.Search.MiniTester.csproj
+++ b/src/NuGet.Services.Search.MiniTester/NuGet.Services.Search.MiniTester.csproj
@@ -81,8 +81,24 @@
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure">
       <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.WindowsAzure.1.0.1304.1\lib\NET45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\packages\Microsoft.Web.Xdt.1.0.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.0.3\lib\net45\Microsoft.WindowsAzure.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Common.NetFramework, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.0.3\lib\net45\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
@@ -98,13 +114,15 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.Core.2.8.1\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Platform">
-      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.11-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
+    <Reference Include="NuGet.Services.Platform, Version=3.0.17.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.17-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.Services.Client" />
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\net45\System.Net.Http.Extensions.dll</HintPath>
@@ -215,10 +233,10 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
-  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.10\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.10\tools\Microsoft.Bcl.Build.targets')" />
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.10\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.10\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/NuGet.Services.Search.MiniTester/Startup.cs
+++ b/src/NuGet.Services.Search.MiniTester/Startup.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Linq;
-using System.Web;
 using System.Web.Configuration;
 using Lucene.Net.Store;
 using Microsoft.Owin;

--- a/src/NuGet.Services.Search.MiniTester/packages.config
+++ b/src/NuGet.Services.Search.MiniTester/packages.config
@@ -8,8 +8,9 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.1.1" targetFramework="net45" />
-  <package id="Microsoft.Bcl" version="1.1.3" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Build" version="1.0.10" targetFramework="net45" />
+  <package id="Microsoft.Bcl" version="1.1.6" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net45" />
@@ -20,10 +21,12 @@
   <package id="Microsoft.Owin.Hosting" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.Common" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.Common.Dependencies" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
   <package id="NuGet.Core" version="2.8.1" targetFramework="net45" />
-  <package id="NuGet.Services.Platform" version="3.0.11-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Platform" version="3.0.17-r-master" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.2" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.2" targetFramework="net45" />

--- a/src/NuGet.Services.Search/NuGet.Services.Search.csproj
+++ b/src/NuGet.Services.Search/NuGet.Services.Search.csproj
@@ -119,8 +119,20 @@
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure">
       <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.WindowsAzure.1.0.1304.1\lib\NET45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\packages\Microsoft.Web.Xdt.1.0.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Common">
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.0.3\lib\net45\Microsoft.WindowsAzure.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Common.NetFramework">
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.0.3\lib\net45\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
@@ -143,13 +155,11 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.Core.2.8.1\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Platform, Version=3.0.11.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.11-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
+    <Reference Include="NuGet.Services.Platform">
+      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.17-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Platform.Client, Version=3.0.11.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.11-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
+    <Reference Include="NuGet.Services.Platform.Client">
+      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.17-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
@@ -157,6 +167,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Services.Client" />
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\net45\System.Net.Http.Extensions.dll</HintPath>

--- a/src/NuGet.Services.Search/SearchConfiguration.cs
+++ b/src/NuGet.Services.Search/SearchConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -9,6 +10,10 @@ namespace NuGet.Services.Search
     public class SearchConfiguration
     {
         public string IndexPath { get; set; }
+        
+        [DefaultValue("ng-search")]
         public string IndexContainer { get; set; }
+        
+        public string StatsContainer { get; set; }
     }
 }

--- a/src/NuGet.Services.Search/packages.config
+++ b/src/NuGet.Services.Search/packages.config
@@ -11,6 +11,7 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.1.1" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.6" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
@@ -24,12 +25,14 @@
   <package id="Microsoft.Owin.Security" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.StaticFiles" version="3.0.0-alpha1" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.Common" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.Common.Dependencies" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
   <package id="NuGet.Core" version="2.8.1" targetFramework="net45" />
   <package id="NuGet.Services.Build" version="3.0.4-rel-4" targetFramework="net45" developmentDependency="true" />
-  <package id="NuGet.Services.Platform" version="3.0.11-r-master" targetFramework="net45" />
-  <package id="NuGet.Services.Platform.Client" version="3.0.11-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Platform" version="3.0.17-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Platform.Client" version="3.0.17-r-master" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.2" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.2" targetFramework="net45" />


### PR DESCRIPTION
Fixes NuGet/NuGetGallery#2192

If you specify a Search.StatsContainer, it looks for the stats reports there. If it's not specified, it looks in the IndexContainer/data folder

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nuget/nuget.services.search/23)

<!-- Reviewable:end -->
