### PR TITLE
Define non-zero freshness value for query that returns most popular packages

### DIFF
--- a/src/NuGet.Services.Search/QueryMiddleware.cs
+++ b/src/NuGet.Services.Search/QueryMiddleware.cs
@@ -82,6 +82,7 @@ namespace NuGet.Services.Search
 
             Query query;
             string content;
+            int maxAgeSeconds = 0;
 
             try
             {
@@ -90,6 +91,7 @@ namespace NuGet.Services.Search
                 if (query == null)
                 {
                     query = new MatchAllDocsQuery();
+                    maxAgeSeconds = 3600;
                 }
                 if (!ignoreFilter && !luceneQuery)
                 {
@@ -129,9 +131,7 @@ namespace NuGet.Services.Search
             }
             finally
             {
-                context.Response.Headers.Add("Pragma", new[] { "no-cache" });
-                context.Response.Headers.Add("Cache-Control", new[] { "no-cache" });
-                context.Response.Headers.Add("Expires", new[] { "0" });
+                context.Response.Headers.Add("Cache-Control", new[] { string.Format("private, max-age={0}", maxAgeSeconds) });
                 context.Response.ContentType = "application/json";
             }
             await context.Response.WriteAsync(content);


### PR DESCRIPTION
Consider this a conceptual PR and not tested code change. I can't build, so I can't test. I removed the pragma no-cache header because that was [obsoleted in 2005](https://support.microsoft.com/en-us/kb/165150) 

I removed the Expires header and replaced it with max-age because they do the same thing but
max-age is easier to specify.  For queries that return all documents I set the max-age to an hour.

Anyone searching for a specific file will use a non-empty q value and therefore the caching max-age will be zero.

Making this change currently will not help because there is an issue with the Nuget client also.  I created a PR for that also https://github.com/NuGet/NuGet3/pull/131
